### PR TITLE
Fix creating circulation on wrong level

### DIFF
--- a/dependencies/ProtoSegment.cs
+++ b/dependencies/ProtoSegment.cs
@@ -11,7 +11,7 @@ namespace Elements
             Geometry = add.Value.Geometry;
             Geometry.Polyline = Geometry.Polyline.Project(Plane.XY);
             AddId = add.Id;
-            var matchingLevelVolume = levelVolumes.FirstOrDefault(lv => lv.AddId == add.Value.Level?.AddId) ??
+            var matchingLevelVolume = levelVolumes.FirstOrDefault(lv => add.Value.Level?.AddId != null && lv.AddId == add.Value.Level?.AddId) ??
                 levelVolumes.FirstOrDefault(lv => lv.Name == add.Value.Level.Name && lv.BuildingName == add.Value.Level.BuildingName) ??
                 levelVolumes.FirstOrDefault(lv => lv.Name == add.Value.Level.Name);
             LevelVolume = matchingLevelVolume;


### PR DESCRIPTION
`LevelVolume` doesn't always have `AddId`, so both Level AddId in `CirculationOverrideAddition` and in `LevelVolume` will be null, which will cause it to always return the first element in the list. Don't use AddId check if it is `null`